### PR TITLE
Enhance drawing tools with undo/redo functionality and commit management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ yarn-error.log*
 
 AGENT_HANDOFF.md
 whiteboard-chat-export.md
+
+docs/

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -4,6 +4,8 @@ import ContextualToolbar from "@/components/ContextualToolbar";
 import Toolbar from "@/components/Toolbar";
 import { useCanvas } from "@/hooks/useCanvas";
 import { useDrawing } from "@/hooks/useDrawing";
+import { useUndoRedo } from "@/hooks/useUndoRedo";
+import { useEffect } from "react";
 import { TOOLS } from "@whiteboard/types/constants/global";
 import {
   CircleIcon,
@@ -16,6 +18,24 @@ import {
 export default function Home() {
   const canvasRef = useCanvas();
   const { portal } = useDrawing(canvasRef as React.RefObject<HTMLCanvasElement | null>);
+  const { undo, redo } = useUndoRedo();
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      const isMac = /mac/i.test(navigator.userAgent) && !/iphone|ipad/i.test(navigator.userAgent);
+      const modKey = isMac ? e.metaKey : e.ctrlKey;
+      if (!modKey) return;
+      if (e.key === "z" && !e.shiftKey) {
+        e.preventDefault();
+        undo();
+      } else if (e.key === "y" || (e.key === "z" && e.shiftKey)) {
+        e.preventDefault();
+        redo();
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [undo, redo]);
 
   return (
     <div className="home-page">
@@ -38,6 +58,8 @@ export default function Home() {
           />
           <Toolbar.Tool icon={<Minus />} tool={TOOLS.LINE} label="Line" />
           <Toolbar.Tool icon={<TypeIcon />} tool={TOOLS.TEXT} label="Text" />
+          <Toolbar.Separator />
+          <Toolbar.UndoRedo />
         </Toolbar>
         <ContextualToolbar className="fixed bottom-3 left-1/2 z-10 -translate-x-1/2" />
         {portal}

--- a/apps/web/components/Toolbar/UndoRedo.tsx
+++ b/apps/web/components/Toolbar/UndoRedo.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { Undo2, Redo2 } from "lucide-react";
+import { useUndoRedo } from "@/hooks/useUndoRedo";
+
+export function UndoRedo() {
+  const { undo, redo, canUndo, canRedo } = useUndoRedo();
+
+  return (
+    <div className="flex flex-col gap-1">
+      <button
+        onClick={undo}
+        disabled={!canUndo}
+        title="Undo (Ctrl+Z)"
+        className="p-2 rounded hover:bg-gray-100 disabled:opacity-30 disabled:cursor-not-allowed"
+      >
+        <Undo2 size={18} />
+      </button>
+      <button
+        onClick={redo}
+        disabled={!canRedo}
+        title="Redo (Ctrl+Y)"
+        className="p-2 rounded hover:bg-gray-100 disabled:opacity-30 disabled:cursor-not-allowed"
+      >
+        <Redo2 size={18} />
+      </button>
+    </div>
+  );
+}

--- a/apps/web/components/Toolbar/index.tsx
+++ b/apps/web/components/Toolbar/index.tsx
@@ -6,6 +6,7 @@ import { TCanvasActions, TCanvasState } from "@/types/canvasStore";
 
 import Separator from "./Separator";
 import Tool from "./Tool";
+import { UndoRedo } from "./UndoRedo";
 import { TooltipProvider } from "../ui/tooltip";
 import { cn } from "@/lib/utils";
 
@@ -48,5 +49,6 @@ export default function Toolbar({
 
 Toolbar.Separator = Separator;
 Toolbar.Tool = Tool;
+Toolbar.UndoRedo = UndoRedo;
 
 export { Toolbar };

--- a/apps/web/history/HistoryManager.ts
+++ b/apps/web/history/HistoryManager.ts
@@ -1,0 +1,62 @@
+import type { Command } from "./types";
+
+type Listener = () => void;
+
+class HistoryManager {
+  private undoStack: Command[] = [];
+  private redoStack: Command[] = [];
+  private listeners: Listener[] = [];
+  private _snapshot = { canUndo: false, canRedo: false };
+
+  private notify() {
+    this._snapshot = {
+      canUndo: this.undoStack.length > 0,
+      canRedo: this.redoStack.length > 0,
+    };
+    this.listeners.forEach((fn) => fn());
+  }
+
+  subscribe(listener: Listener): () => void {
+    this.listeners.push(listener);
+    return () => {
+      this.listeners = this.listeners.filter((l) => l !== listener);
+    };
+  }
+
+  getSnapshot() {
+    return this._snapshot;
+  }
+
+  execute(command: Command): void {
+    command.execute();
+    this.undoStack.push(command);
+    this.redoStack = [];
+    this.notify();
+  }
+
+  undo(): void {
+    const command = this.undoStack.pop();
+    if (!command) return;
+    command.undo();
+    this.redoStack.push(command);
+    this.notify();
+  }
+
+  redo(): void {
+    const command = this.redoStack.pop();
+    if (!command) return;
+    command.execute();
+    this.undoStack.push(command);
+    this.notify();
+  }
+
+  get canUndo(): boolean {
+    return this.undoStack.length > 0;
+  }
+
+  get canRedo(): boolean {
+    return this.redoStack.length > 0;
+  }
+}
+
+export const historyManager = new HistoryManager();

--- a/apps/web/history/commands/AddElementCommand.ts
+++ b/apps/web/history/commands/AddElementCommand.ts
@@ -1,0 +1,17 @@
+import type { Command } from "../types";
+import type { TElement } from "@whiteboard/types";
+import { useCanvasStore } from "@/store/canvasStore";
+
+export class AddElementCommand implements Command {
+  constructor(private element: TElement) {}
+
+  execute(): void {
+    useCanvasStore.getState().addElement(this.element);
+  }
+
+  undo(): void {
+    useCanvasStore.setState((state) => ({
+      elements: state.elements.slice(0, -1),
+    }));
+  }
+}

--- a/apps/web/history/commands/CommitLastElementCommand.ts
+++ b/apps/web/history/commands/CommitLastElementCommand.ts
@@ -1,0 +1,29 @@
+import type { Command } from "../types";
+import type { TElement } from "@whiteboard/types";
+import { useCanvasStore } from "@/store/canvasStore";
+
+export class CommitLastElementCommand implements Command {
+  private element: TElement;
+  private firstRun = true;
+
+  constructor() {
+    const elements = useCanvasStore.getState().elements;
+    this.element = elements[elements.length - 1]!;
+  }
+
+  execute(): void {
+    if (this.firstRun) {
+      this.firstRun = false;
+      return;
+    }
+    useCanvasStore.setState((state) => ({
+      elements: [...state.elements, this.element],
+    }));
+  }
+
+  undo(): void {
+    useCanvasStore.setState((state) => ({
+      elements: state.elements.slice(0, -1),
+    }));
+  }
+}

--- a/apps/web/history/commands/UpdateElementCommand.ts
+++ b/apps/web/history/commands/UpdateElementCommand.ts
@@ -1,0 +1,27 @@
+import type { Command } from "../types";
+import type { TElement } from "@whiteboard/types";
+import { useCanvasStore } from "@/store/canvasStore";
+
+export class UpdateElementCommand implements Command {
+  constructor(
+    private before: TElement,
+    private after: TElement,
+    private index: number,
+  ) {}
+
+  execute(): void {
+    useCanvasStore.setState((state) => ({
+      elements: state.elements.map((el, i) =>
+        i === this.index ? this.after : el,
+      ),
+    }));
+  }
+
+  undo(): void {
+    useCanvasStore.setState((state) => ({
+      elements: state.elements.map((el, i) =>
+        i === this.index ? this.before : el,
+      ),
+    }));
+  }
+}

--- a/apps/web/history/types.ts
+++ b/apps/web/history/types.ts
@@ -1,0 +1,4 @@
+export interface Command {
+  execute(): void;
+  undo(): void;
+}

--- a/apps/web/hooks/drawing/types.ts
+++ b/apps/web/hooks/drawing/types.ts
@@ -7,11 +7,13 @@ export type DrawContext = {
   updateLastElement: (updater: (el: TElement) => TElement) => void;
   addPoint: (point: TPoint) => void;
   origin: TPoint;
+  commitElement: (element: TElement) => void;
 };
 
 export type ToolHandler = {
   onDown: (point: TPoint, ctx: DrawContext) => void;
   onMove: (point: TPoint, ctx: DrawContext) => void;
+  onUp?: (ctx: DrawContext) => void;
 };
 
 export type ElementRenderer = (

--- a/apps/web/hooks/tools/useEllipseTool.ts
+++ b/apps/web/hooks/tools/useEllipseTool.ts
@@ -1,6 +1,8 @@
 import type { TEllipse } from "@whiteboard/types";
 import { FILL_MODES } from "@whiteboard/types/constants/global";
 import type { ElementRenderer, ToolDefinition, ToolHandler } from "../drawing/types";
+import { historyManager } from "@/history/HistoryManager";
+import { CommitLastElementCommand } from "@/history/commands/CommitLastElementCommand";
 
 const handler: ToolHandler = {
   onDown: (point, { addElement, getState }) => {
@@ -27,6 +29,9 @@ const handler: ToolHandler = {
       radiusX: Math.abs(dx / 2),
       radiusY: Math.abs(dy / 2),
     }));
+  },
+  onUp() {
+    historyManager.execute(new CommitLastElementCommand());
   },
 };
 

--- a/apps/web/hooks/tools/useLineTool.ts
+++ b/apps/web/hooks/tools/useLineTool.ts
@@ -1,6 +1,8 @@
 import type { TLine } from "@whiteboard/types";
 import { ARROW_HEADS, DASH_STYLES } from "@whiteboard/types/constants/global";
 import type { ElementRenderer, ToolDefinition, ToolHandler } from "../drawing/types";
+import { historyManager } from "@/history/HistoryManager";
+import { CommitLastElementCommand } from "@/history/commands/CommitLastElementCommand";
 
 const handler: ToolHandler = {
   onDown: (point, { addElement, getState }) => {
@@ -19,6 +21,9 @@ const handler: ToolHandler = {
   },
   onMove: (point, { updateLastElement }) => {
     updateLastElement((el) => ({ ...el, endPoint: point }));
+  },
+  onUp() {
+    historyManager.execute(new CommitLastElementCommand());
   },
 };
 

--- a/apps/web/hooks/tools/usePencilTool.ts
+++ b/apps/web/hooks/tools/usePencilTool.ts
@@ -1,5 +1,7 @@
 import type { TStroke } from "@whiteboard/types";
 import type { DrawContext, ElementRenderer, ToolDefinition, ToolHandler } from "../drawing/types";
+import { historyManager } from "@/history/HistoryManager";
+import { CommitLastElementCommand } from "@/history/commands/CommitLastElementCommand";
 
 const handler: ToolHandler = {
   onDown: (point, { addElement, getState }) => {
@@ -15,6 +17,9 @@ const handler: ToolHandler = {
   },
   onMove: (point, { addPoint }: DrawContext) => {
     addPoint(point);
+  },
+  onUp() {
+    historyManager.execute(new CommitLastElementCommand());
   },
 };
 

--- a/apps/web/hooks/tools/useRectangleTool.ts
+++ b/apps/web/hooks/tools/useRectangleTool.ts
@@ -1,6 +1,8 @@
 import type { TRectangle } from "@whiteboard/types";
 import { FILL_MODES } from "@whiteboard/types/constants/global";
 import type { ElementRenderer, ToolDefinition, ToolHandler } from "../drawing/types";
+import { historyManager } from "@/history/HistoryManager";
+import { CommitLastElementCommand } from "@/history/commands/CommitLastElementCommand";
 
 const handler: ToolHandler = {
   onDown: (point, { addElement, getState }) => {
@@ -23,6 +25,9 @@ const handler: ToolHandler = {
       width: point.x - origin.x,
       height: point.y - origin.y,
     }));
+  },
+  onUp() {
+    historyManager.execute(new CommitLastElementCommand());
   },
 };
 

--- a/apps/web/hooks/tools/useTextTool.tsx
+++ b/apps/web/hooks/tools/useTextTool.tsx
@@ -3,6 +3,8 @@ import { createPortal } from "react-dom";
 import type { TText } from "@whiteboard/types";
 import { useCanvasStore } from "@/store/canvasStore";
 import type { ElementRenderer, ToolDefinition, ToolHandler } from "../drawing/types";
+import { historyManager } from "@/history/HistoryManager";
+import { CommitLastElementCommand } from "@/history/commands/CommitLastElementCommand";
 
 const renderer: ElementRenderer = (ctx, el) => {
   const text = el as TText;
@@ -56,6 +58,7 @@ export function useTextTool(): ToolDefinition & { portal: React.ReactNode } {
             : el,
         ),
       }));
+      historyManager.execute(new CommitLastElementCommand());
     } else {
       setState((state) => ({
         elements: state.elements.filter(

--- a/apps/web/hooks/useDrawing.ts
+++ b/apps/web/hooks/useDrawing.ts
@@ -9,6 +9,8 @@ import { useLineTool } from "./tools/useLineTool";
 import { usePencilTool } from "./tools/usePencilTool";
 import { useRectangleTool } from "./tools/useRectangleTool";
 import { useTextTool } from "./tools/useTextTool";
+import { historyManager } from "@/history/HistoryManager";
+import { AddElementCommand } from "@/history/commands/AddElementCommand";
 
 export function useDrawing(
   canvasRef: React.RefObject<HTMLCanvasElement | null>,
@@ -60,6 +62,9 @@ export function useDrawing(
         updateLastElement,
         addPoint,
         origin: point,
+        commitElement: (element) => {
+          historyManager.execute(new AddElementCommand(element));
+        },
       };
 
       toolHandlers[getState().activeTool]?.onDown(point, drawCtx);
@@ -68,6 +73,19 @@ export function useDrawing(
 
     const handleMouseUp = (e: MouseEvent) => {
       e.preventDefault();
+      if (isDrawing.current) {
+        const drawCtx: DrawContext = {
+          getState,
+          addElement,
+          updateLastElement,
+          addPoint,
+          origin: originRef.current ?? { x: 0, y: 0 },
+          commitElement: (element) => {
+            historyManager.execute(new AddElementCommand(element));
+          },
+        };
+        toolHandlers[getState().activeTool]?.onUp?.(drawCtx);
+      }
       isDrawing.current = false;
       originRef.current = null;
     };
@@ -84,6 +102,9 @@ export function useDrawing(
         updateLastElement,
         addPoint,
         origin: originRef.current,
+        commitElement: (element) => {
+          historyManager.execute(new AddElementCommand(element));
+        },
       };
 
       toolHandlers[getState().activeTool]?.onMove(point, drawCtx);
@@ -112,6 +133,18 @@ export function useDrawing(
       canvas.removeEventListener("mouseleave", handleMouseLeave);
     };
   }, [canvasRef, addElement, updateLastElement, addPoint, getState, toolHandlers, elementRenderers]);
+
+  // Redraw when elements change externally (undo/redo) while not actively drawing
+  useEffect(() => {
+    return useCanvasStore.subscribe((state, prev) => {
+      if (state.elements !== prev.elements && !isDrawing.current) {
+        const canvas = canvasRef.current;
+        if (!canvas) return;
+        const ctx = canvas.getContext("2d");
+        reDraw(ctx, state.elements, elementRenderers);
+      }
+    });
+  }, [canvasRef, elementRenderers]);
 
   return { portal: text.portal };
 }

--- a/apps/web/hooks/useUndoRedo.ts
+++ b/apps/web/hooks/useUndoRedo.ts
@@ -1,0 +1,19 @@
+import { useCallback, useSyncExternalStore } from "react";
+import { historyManager } from "@/history/HistoryManager";
+
+function subscribe(callback: () => void) {
+  return historyManager.subscribe(callback);
+}
+
+function getSnapshot() {
+  return historyManager.getSnapshot();
+}
+
+export function useUndoRedo() {
+  const { canUndo, canRedo } = useSyncExternalStore(subscribe, getSnapshot, () => ({ canUndo: false, canRedo: false }));
+
+  const undo = useCallback(() => historyManager.undo(), []);
+  const redo = useCallback(() => historyManager.redo(), []);
+
+  return { undo, redo, canUndo, canRedo };
+}


### PR DESCRIPTION
- Integrated undo and redo capabilities using keyboard shortcuts (Ctrl+Z/Cmd+Z for undo, Ctrl+Y/Cmd+Y for redo).
- Updated the useDrawing hook to manage element commits through a history manager.
- Enhanced tool handlers for line, rectangle, ellipse, pencil, and text tools to commit elements upon completion.
- Refactored Toolbar to include an UndoRedo component for user interaction.
- Improved type definitions to support new commit functionality in drawing context.