### PR TITLE
feat(web): enhance drawing tool functionality and keyboard shortcuts

### DIFF
--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -10,7 +10,9 @@ import { type CursorInfo, type UserInfo, useSocket } from "@/hooks/useSocket";
 import { useCursorSync } from "@/hooks/useCursorSync";
 import { useUndoRedo } from "@/hooks/useUndoRedo";
 import { useCallback, useEffect, useState } from "react";
+import { useCanvasStore } from "@/store/canvasStore";
 import { TOOLS } from "@whiteboard/types/constants/global";
+import { TOOL_KEYS } from "@/constants/tools";
 import {
   CircleIcon,
   Minus,
@@ -21,8 +23,12 @@ import {
 
 export default function Home() {
   const canvasRef = useCanvas();
-  const { portal } = useDrawing(canvasRef as React.RefObject<HTMLCanvasElement | null>);
+  const { portal } = useDrawing(
+    canvasRef as React.RefObject<HTMLCanvasElement | null>,
+  );
   const { undo, redo } = useUndoRedo();
+  const setActiveTool = useCanvasStore((state) => state.setActiveTool);
+  const setIsEraser = useCanvasStore((state) => state.setIsEraser);
   const [cursors, setCursors] = useState<Record<string, CursorInfo>>({});
   const [users, setUsers] = useState<UserInfo[]>([]);
 
@@ -41,24 +47,45 @@ export default function Home() {
   const onUsersChange = useCallback((u: UserInfo[]) => setUsers(u), []);
 
   const { emitCursor } = useSocket(onCursorMove, onUserLeft, onUsersChange);
-  useCursorSync(canvasRef as React.RefObject<HTMLCanvasElement | null>, emitCursor);
+  useCursorSync(
+    canvasRef as React.RefObject<HTMLCanvasElement | null>,
+    emitCursor,
+  );
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      const isMac = /mac/i.test(navigator.userAgent) && !/iphone|ipad/i.test(navigator.userAgent);
+      // Skip if typing in an input/textarea
+      if (
+        e.target instanceof HTMLInputElement ||
+        e.target instanceof HTMLTextAreaElement
+      )
+        return;
+
+      const isMac =
+        /mac/i.test(navigator.userAgent) &&
+        !/iphone|ipad/i.test(navigator.userAgent);
       const modKey = isMac ? e.metaKey : e.ctrlKey;
-      if (!modKey) return;
-      if (e.key === "z" && !e.shiftKey) {
-        e.preventDefault();
-        undo();
-      } else if (e.key === "y" || (e.key === "z" && e.shiftKey)) {
-        e.preventDefault();
-        redo();
+
+      if (modKey) {
+        if (e.key === "z" && !e.shiftKey) {
+          e.preventDefault();
+          undo();
+        } else if (e.key === "y" || (e.key === "z" && e.shiftKey)) {
+          e.preventDefault();
+          redo();
+        }
+        return;
+      }
+
+      const binding = TOOL_KEYS[e.key.toLowerCase()];
+      if (binding) {
+        setActiveTool(binding.tool);
+        setIsEraser(binding.eraser);
       }
     };
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [undo, redo]);
+  }, [undo, redo, setActiveTool, setIsEraser]);
 
   return (
     <div className="home-page">
@@ -69,19 +96,32 @@ export default function Home() {
             icon={<PencilLineIcon />}
             tool={TOOLS.PENCIL}
             label="Pen"
+            shortcut="P"
           />
           <Toolbar.Tool
             icon={<RectangleHorizontalIcon />}
             tool={TOOLS.RECTANGLE}
             label="Rectangle"
+            shortcut="R"
           />
           <Toolbar.Tool
             icon={<CircleIcon />}
             tool={TOOLS.CIRCLE}
             label="Circle"
+            shortcut="C"
           />
-          <Toolbar.Tool icon={<Minus />} tool={TOOLS.LINE} label="Line" />
-          <Toolbar.Tool icon={<TypeIcon />} tool={TOOLS.TEXT} label="Text" />
+          <Toolbar.Tool
+            icon={<Minus />}
+            tool={TOOLS.LINE}
+            label="Line"
+            shortcut="L"
+          />
+          <Toolbar.Tool
+            icon={<TypeIcon />}
+            tool={TOOLS.TEXT}
+            label="Text"
+            shortcut="T"
+          />
           <Toolbar.Separator />
           <Toolbar.UndoRedo />
         </Toolbar>

--- a/apps/web/components/Toolbar/Tool.tsx
+++ b/apps/web/components/Toolbar/Tool.tsx
@@ -13,10 +13,11 @@ type TToolProps = {
   icon: React.ReactNode;
   tool: TTool;
   label: string;
+  shortcut?: string;
 };
 
 export default function Tool(props: TToolProps) {
-  const { icon, tool, label } = props;
+  const { icon, tool, label, shortcut } = props;
   const { activeTool, setActiveTool } = useToolBar();
 
   const handleClick = () => {
@@ -42,7 +43,7 @@ export default function Tool(props: TToolProps) {
         </Button>
       </TooltipTrigger>
       <TooltipContent side="right" sideOffset={8}>
-        <p>{label}</p>
+        <p>{label}{shortcut && <kbd className="ml-2 opacity-60 text-[10px] border border-current rounded px-1">{shortcut}</kbd>}</p>
       </TooltipContent>
     </Tooltip>
   );

--- a/apps/web/constants/tools.ts
+++ b/apps/web/constants/tools.ts
@@ -1,0 +1,11 @@
+import { TOOLS } from "@whiteboard/types/constants/global";
+import type { TTool } from "@whiteboard/types";
+
+export const TOOL_KEYS: Record<string, { tool: TTool; eraser: boolean }> = {
+  p: { tool: TOOLS.PENCIL, eraser: false },
+  r: { tool: TOOLS.RECTANGLE, eraser: false },
+  c: { tool: TOOLS.CIRCLE, eraser: false },
+  l: { tool: TOOLS.LINE, eraser: false },
+  t: { tool: TOOLS.TEXT, eraser: false },
+  e: { tool: TOOLS.PENCIL, eraser: true },
+};


### PR DESCRIPTION
- Integrated canvas store to manage active drawing tools and eraser state.
- Added keyboard shortcuts for selecting drawing tools (Pencil, Rectangle, Circle, Line, Text) and toggling the eraser.
- Improved keydown event handling to prevent default actions when typing in input fields.
- Updated Toolbar component to display shortcuts for each tool.